### PR TITLE
Refresh with element IDs

### DIFF
--- a/src/Manager.js
+++ b/src/Manager.js
@@ -526,6 +526,11 @@
 
         units = units || definedSlots;
 
+        // Convert element IDs to googletag slot references
+        units = $.map( units, function ( unit ) {
+            return 'string' === typeof unit ? getDefinedSlot( unit ) : unit;
+        } );
+
         googletag.cmd.push( function () {
             googletag.pubads().refresh( units );
         } );


### PR DESCRIPTION
Update the `refresh()` function to accept an array of element IDs when triggering the `AdManager:refresh` event. 

Previously `refresh()` expected an array of DFP slot references, which aren't exposed outside of AdManager when created. If we only know the IDs of the divs we want to refresh, we can pass in an array of those IDs to the `AdManager:refresh` event and `refresh()` will loop through those IDs and find the corresponding slots in the inventory.